### PR TITLE
Added Makefile

### DIFF
--- a/game/Makefile
+++ b/game/Makefile
@@ -1,0 +1,89 @@
+GAME=from_below
+SONGS=MUSIC/songs.s
+SOUNDS=MUSIC/sounds.s
+CC=cc65
+CA=ca65
+LD=ld65
+text2data=text2data
+nsf2data=nsf2data
+CFLAGS=-Oirs
+DBGFLAGS=-g --add-source
+ADBGFLAGS=-g
+VSON=-D VS_SYS_ENABLED=1 -D VS_SRAM_ENABLED=0
+VSOFF=-D VS_SYS_ENABLED=0 -D VS_SRAM_ENABLED=0
+LDFLAGS=-C nrom_32k_vert.cfg --dbgfile main.dbg -Ln labels.txt
+
+GIT_COMMIT:=$(if $(shell git log -1 2>/dev/null),_$(shell git log -1 --date=format:%Y_%m_%d --pretty=format:"%ad" 2>/dev/null),)
+
+all: audio nes vssys
+default: nes vssys
+
+nes = BUILD/$(GAME)$(GIT_COMMIT).nes
+vssys = BUILD/$(GAME)_vs$(GIT_COMMIT).nes
+
+nes: $(nes)
+vssys: $(vssys)
+
+$(SONGS): 
+	$(text2data) MUSIC/songs.txt -ca65
+
+$(SOUNDS):
+	$(nsf2data) MUSIC/sounds.nsf -ca65
+
+AUDIO = $(SONGS) $(SOUNDS)
+
+audio: $(AUDIO)
+
+$(GAME).s:
+	$(CC) -o $@ $(DBGFLAGS) $(CFLAGS) $(VSOFF) main.c
+
+$(GAME)_vs.s:
+	$(CC) -o $@ $(DBGFLAGS) $(CFLAGS) $(VSON) main.c
+
+crt0.o: crt0.s $(AUDIO)
+	$(CA) -o $@ $(VSOFF) crt0.s
+
+crt0_vs.o: crt0.s $(AUDIO)
+	$(CA) -o $@ $(VSON) crt0.s
+
+$(GAME).o: $(GAME).s
+	$(CA) -o $@ $(GAME).s $(ADBGFLAGS)
+
+$(GAME)_vs.o: $(GAME)_vs.s
+	$(CA) -o $@ from_below_vs.s $(ADBGFLAGS)
+
+nes_obj = crt0.o $(GAME).o
+
+vs_obj = crt0_vs.o $(GAME)_vs.o
+
+BUILD/$(GAME)$(GIT_COMMIT).nes: $(nes_obj)
+	-mkdir -p BUILD
+	$(LD) -o $@ $(LDFLAGS) $(nes_obj) nes.lib
+
+BUILD/$(GAME)_vs$(GIT_COMMIT).nes: $(vs_obj)
+	-mkdir -p BUILD
+	$(LD) -o $@ $(LDFLAGS) $(vs_obj) nes.lib
+
+
+clean-audio:
+	-rm $(SONGS) $(SOUNDS)
+
+clean-nes:
+	rm -f crt0.o $(GAME).o $(GAME).s *.dbg $(nes) labels.txt
+	-rmdir BUILD || true
+
+clean-vs:
+	rm -f crt0_vs.o $(GAME)_vs.o $(GAME)_vs.s *.dbg $(vssys) labels.txt
+	-rmdir BUILD || true
+
+clean-obj-nes:
+	rm -f crt0.o $(GAME).o $(GAME).s *.dbg labels.txt
+
+clean-obj-vs:
+	rm -f crt0_vs.o $(GAME)_vs.o $(GAME)_vs.s *.dbg labels.txt
+
+clean-obj: clean-obj-nes clean-obj-vs
+
+clean: clean-nes clean-vs
+
+clean-all: clean-audio clean


### PR DESCRIPTION
Makefile for POSIX systems.  

Could be simplified to be less redundant, but is able to create the chain of assembler/object/.nes files for whichever file has been updated, as Make intends.  
* Make Targets: all audio nes vssys clean clean-all clean-audio clean-nes clean-vs clean-obj
* Can even create NES and VS-System builds in parallel with make -j2 since they don't have codependent assembler or object files.  
* Appends the git commit date to .nes filenames, Also handles if source tree is not a git repo.
* By default, clean does not remove the sounds.s and songs.s assembler files. if you do make clean-all or make clean-audio, it'll remove them, and you'd need text2data and nsf2data to create them again (or checkout the assembled copies from git again)
* The default target will not regenerate MUSIC/songs.s or MUSIC/sounds.s unless they are missing, Use make all or make audio if they are to be rebuilt when the assembled copies have not been deleted.
